### PR TITLE
Adding unique ID to push notification plugin

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -12,10 +12,12 @@ import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
+import java.util.Random;
+
 @SuppressLint("NewApi")
 public class GCMIntentService extends GCMBaseIntentService {
 
-    public static final int NOTIFICATION_ID = 237;
+    public final int NOTIFICATION_ID = 1;
 
     private static String TAG = "PushPlugin-GCMIntentService";
 
@@ -58,12 +60,15 @@ public class GCMIntentService extends GCMBaseIntentService {
         NotificationManager mNotificationManager = (NotificationManager) getSystemService(
                 Context.NOTIFICATION_SERVICE);
         String appName = getAppName(this);
+        int notId = ++NOTIFICATION_ID;
 
         Intent notificationIntent = new Intent(this, PushHandlerActivity.class);
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         notificationIntent.putExtra("pushBundle", extras);
+        notificationIntent.putExtra(NOT_ID, notId);
 
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent,
+        int requestCode = new Random().nextInt();
+        PendingIntent contentIntent = PendingIntent.getActivity(this, requestCode, notificationIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT);
 
         int defaults = Notification.DEFAULT_ALL;
@@ -103,8 +108,6 @@ public class GCMIntentService extends GCMBaseIntentService {
         if (msgcnt != null) {
             mBuilder.setNumber(Integer.parseInt(msgcnt));
         }
-
-        int notId = NOTIFICATION_ID;
 
         try {
             notId = Integer.parseInt(extras.getString("notId"));


### PR DESCRIPTION
This unique id is required for each push notification. So that push notification does not collapse